### PR TITLE
Implement event management system with PDF preview support

### DIFF
--- a/admin/components/PdfPreviewModal.tsx
+++ b/admin/components/PdfPreviewModal.tsx
@@ -52,19 +52,11 @@ const PdfPreviewModal: React.FC<PdfPreviewModalProps> = ({ isOpen, onClose, pdfU
 
         {/* Content */}
         <div className="flex-1 bg-slate-100 p-2 sm:p-4 rounded-b-2xl overflow-hidden relative">
-          {safePdfUrl.startsWith('data:') || safePdfUrl.startsWith('blob:') ? (
-            <iframe
-              src={safePdfUrl}
-              className="w-full h-full rounded-xl bg-white shadow-sm border border-slate-200"
-              title={title}
-            />
-          ) : (
-            <iframe
-              src={`https://docs.google.com/viewer?url=${encodeURIComponent(safePdfUrl)}&embedded=true`}
-              className="w-full h-full rounded-xl bg-white shadow-sm border border-slate-200"
-              title={title}
-            />
-          )}
+          <iframe
+            src={safePdfUrl}
+            className="w-full h-full rounded-xl bg-white shadow-sm border border-slate-200"
+            title={title}
+          />
         </div>
       </div>
     </div>

--- a/admin/pages/events/EventForm.tsx
+++ b/admin/pages/events/EventForm.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams, Link } from 'react-router-dom';
 import { eventsApi } from '../../api/events';
 import type { EventPayload } from '../../types';
-import PdfPreviewModal from '../../components/PdfPreviewModal';
 import PageEditorHeader from '../../../components/admin/PageEditorHeader';
 
 const CATEGORIES = ['Academic', 'Cultural', 'Sports', 'Technical', 'Workshop', 'Other'];
@@ -40,7 +39,6 @@ const EventForm: React.FC = () => {
   const [saving, setSaving] = useState(false);
   const [loading, setLoading] = useState(isEdit);
   const [error, setError] = useState('');
-  const [previewOpen, setPreviewOpen] = useState(false);
 
   useEffect(() => {
     if (!isEdit) return;
@@ -149,12 +147,7 @@ const EventForm: React.FC = () => {
 
   return (
     <div className="max-w-3xl mx-auto space-y-8 pb-12">
-      <PdfPreviewModal 
-        isOpen={previewOpen} 
-        onClose={() => setPreviewOpen(false)} 
-        pdfUrl={pdfPreviewToUse} 
-        title={form.title || 'PDF Preview'} 
-      />
+
 
       <PageEditorHeader
         title={isEdit ? 'Edit Event' : 'Add New Event'}
@@ -318,14 +311,15 @@ const EventForm: React.FC = () => {
                   <p className="text-xs text-emerald-600 font-bold uppercase tracking-wide">Ready for upload</p>
                 </div>
               </div>
-              <button
-                type="button"
-                onClick={() => setPreviewOpen(true)}
+              <a
+                href={pdfPreviewToUse ?? '#'}
+                target="_blank"
+                rel="noreferrer"
                 className="ml-4 px-4 py-2 bg-blue-50 text-blue-700 hover:bg-blue-100 rounded-lg text-xs font-bold transition-colors flex items-center gap-2 whitespace-nowrap"
               >
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2.5" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" /><path strokeLinecap="round" strokeLinejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" /></svg>
                 Preview
-              </button>
+              </a>
             </div>
           )}
         </div>

--- a/admin/pages/events/EventsList.tsx
+++ b/admin/pages/events/EventsList.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { eventsApi } from '../../api/events';
 import type { Event } from '../../types';
-import PdfPreviewModal from '../../components/PdfPreviewModal';
 
 const EventsList: React.FC = () => {
   const [events, setEvents] = useState<Event[]>([]);
@@ -46,8 +45,6 @@ const EventsList: React.FC = () => {
   // Action State
   const [deletingId, setDeletingId] = useState<number | null>(null);
   const [updatingId, setUpdatingId] = useState<number | null>(null);
-  const [previewPdfUrl, setPreviewPdfUrl] = useState<string | null>(null);
-  const [previewTitle, setPreviewTitle] = useState('');
 
   const load = () => {
     setLoading(true);
@@ -131,12 +128,7 @@ const EventsList: React.FC = () => {
 
   return (
     <div className="space-y-10 pb-12">
-      <PdfPreviewModal 
-        isOpen={!!previewPdfUrl} 
-        onClose={() => setPreviewPdfUrl(null)} 
-        pdfUrl={previewPdfUrl} 
-        title={previewTitle} 
-      />
+
 
       {/* Header */}
       <div className="flex items-center justify-between">
@@ -275,13 +267,15 @@ const EventsList: React.FC = () => {
                           <span className="text-slate-900 font-bold truncate block">{ev.title}</span>
                           <span className="text-xs text-slate-500 truncate block">{ev.organizer || 'VCET'}</span>
                           {eventWithAttachment.attachment ? (
-                            <button 
-                              onClick={() => { setPreviewTitle(ev.title); setPreviewPdfUrl(eventWithAttachment.attachment); }}
+                            <a
+                              href={eventWithAttachment.attachment}
+                              target="_blank"
+                              rel="noreferrer"
                               className="self-start inline-flex items-center gap-1.5 text-xs font-semibold text-[#2563EB] hover:text-blue-800 transition-colors bg-blue-50 px-2 py-1 rounded-md mt-1"
                             >
                               <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="2.5" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" /><path strokeLinecap="round" strokeLinejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" /></svg>
                               Preview PDF
-                            </button>
+                            </a>
                           ) : (
                             <span className="text-xs text-slate-400 italic mt-1">No PDF Attached</span>
                           )}


### PR DESCRIPTION
This pull request removes the in-app PDF preview modal functionality from both the event form and events list, replacing it with direct links that open PDF attachments in a new browser tab. This simplifies the user experience and codebase by eliminating the `PdfPreviewModal` component and related state management.

**PDF Preview Functionality Simplification:**

* Removed the `PdfPreviewModal` component and all related imports, state, and usage from both `EventForm.tsx` and `EventsList.tsx`. [[1]](diffhunk://#diff-8b78a1e6af527b2b03cf38765867831a66536f5b9088b52d97fa4f76a3c1c287L5) [[2]](diffhunk://#diff-8b78a1e6af527b2b03cf38765867831a66536f5b9088b52d97fa4f76a3c1c287L43) [[3]](diffhunk://#diff-8b78a1e6af527b2b03cf38765867831a66536f5b9088b52d97fa4f76a3c1c287L152-R150) [[4]](diffhunk://#diff-7ca70ce0c170df31d4c9251deaeaee42eef0c2a426fac0d6c3077491fd1fddfeL5) [[5]](diffhunk://#diff-7ca70ce0c170df31d4c9251deaeaee42eef0c2a426fac0d6c3077491fd1fddfeL49-L50) [[6]](diffhunk://#diff-7ca70ce0c170df31d4c9251deaeaee42eef0c2a426fac0d6c3077491fd1fddfeL134-R131)
* Replaced the "Preview" button in both event form and events list with anchor (`<a>`) tags that open the PDF attachment in a new browser tab using `target="_blank"` and `rel="noreferrer"`. [[1]](diffhunk://#diff-8b78a1e6af527b2b03cf38765867831a66536f5b9088b52d97fa4f76a3c1c287L321-R322) [[2]](diffhunk://#diff-7ca70ce0c170df31d4c9251deaeaee42eef0c2a426fac0d6c3077491fd1fddfeL278-R278)

**Component Cleanup:**

* Removed conditional logic in `PdfPreviewModal.tsx` that handled Google Docs viewer for non-blob/data URLs, as the modal is no longer used.